### PR TITLE
feat: add repoRecentReleases

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,21 @@ Last Release: {{humanize .LastRelease.PublishedAt}}
 {{end}}
 ```
 
+### Recent releases to a given repository
+
+```
+{{range recentRepoReleases "charmbracelet" "markscribe" 10}}
+Name: {{.Name}}
+Git Tag: {{.TagName}}
+URL: {{.URL}}
+Published: {{humanize .PublishedAt}}
+CreatedAt: {{humanize .CreatedAt}}
+IsPreRelease: {{.IsPreRelease}}
+IsDraft: {{.IsDraft}}
+IsLatest: {{.IsLatest}}
+{{end}}
+```
+
 This function requires GitHub authentication with the following API scopes:
 `repo:status`, `public_repo`, `read:user`.
 

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func main() {
 	funcMap["gists"] = gists
 	funcMap["sponsors"] = sponsors
 	funcMap["repo"] = repo
+	funcMap["repoRecentReleases"] = repoRecentReleases
 	/* RSS */
 	funcMap["rss"] = rssFeed
 	/* GoodReads */

--- a/repos.go
+++ b/repos.go
@@ -88,7 +88,7 @@ var repoQuery struct {
 
 var repoRecentReleasesQuery struct {
 	Repository struct {
-		Releases qlRelease `graphql:"releases(first: 10, orderBy: {field: CREATED_AT, direction: DESC})"`
+		Releases qlRelease `graphql:"releases(first: $count, orderBy: {field: CREATED_AT, direction: DESC})"`
 	} `graphql:"repository(name: $name, owner: $owner)"`
 }
 

--- a/repos.go
+++ b/repos.go
@@ -333,9 +333,6 @@ func repoRecentReleases(owner, name string, count int) []Release {
 		})
 	}
 
-	if len(releases) > count {
-		return releases[:count]
-	}
 	return releases
 }
 

--- a/repos.go
+++ b/repos.go
@@ -310,6 +310,7 @@ func repoRecentReleases(owner, name string, count int) []Release {
 	variables := map[string]interface{}{
 		"owner": githubv4.String(owner),
 		"name":  githubv4.String(name),
+		"count": githubv4.Int(count),
 	}
 	err := gitHubClient.Query(context.Background(), &repoRecentReleasesQuery, variables)
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -37,10 +37,14 @@ type PullRequest struct {
 
 // Release represents a release.
 type Release struct {
-	Name        string
-	TagName     string
-	PublishedAt time.Time
-	URL         string
+	Name         string
+	TagName      string
+	PublishedAt  time.Time
+	CreatedAt    time.Time
+	URL          string
+	IsLatest     bool
+	IsPreRelease bool
+	IsDraft      bool
 }
 
 // Repo represents a git repo.
@@ -89,8 +93,10 @@ type qlRelease struct {
 		Name         githubv4.String
 		TagName      githubv4.String
 		PublishedAt  githubv4.DateTime
+		CreatedAt    githubv4.DateTime
 		URL          githubv4.String
 		IsPrerelease githubv4.Boolean
+		IsLatest     githubv4.Boolean
 		IsDraft      githubv4.Boolean
 	}
 }


### PR DESCRIPTION
Adds a `repoRecentReleases` command that fetches the latest releases for a given repository.

Reference: https://github.com/muesli/markscribe/pull/84