### PR TITLE
feat(rss): map charm members to their github profiles

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -1,10 +1,20 @@
 package main
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/mmcdole/gofeed"
 )
+
+var team = map[string]string{
+	"Christian Rocha": "meowgorithm",
+	"Bashbunni":       "bashbunni",
+	"Ayman Bagabas":   "aymanbagabas",
+	"Carlos Becker":   "caarlos0",
+	"Maas Lalani":     "maaslalani",
+	"Charm":           "charmbracelet",
+}
 
 // RSSEntry represents a single RSS entry.
 type RSSEntry struct {
@@ -26,18 +36,22 @@ func rssFeed(url string, count int) []RSSEntry {
 
 	for _, v := range feed.Items {
 		// fmt.Printf("%+v\n", v)
+		author := v.Author.Name
+		if profile, ok := team[v.Author.Name]; ok {
+			author = fmt.Sprintf("[%s](https://github.com/%s)", profile, profile)
+		}
 
 		r = append(r, RSSEntry{
 			Title:       v.Title,
-			Author:      v.Author.Name,
+			Author:      author,
 			Description: v.Description,
 			URL:         v.Link,
 			PublishedAt: *v.PublishedParsed,
 		})
+
 		if len(r) == count {
 			break
 		}
 	}
-
 	return r
 }

--- a/templates/rss.tpl
+++ b/templates/rss.tpl
@@ -1,0 +1,11 @@
+# Bloggin'
+
+{{- range rss "https://charm.sh/blog/rss.xml" 5}}
+- [{{.Title}}]({{.URL}}): {{.Description}} by {{.Author}} (_released {{humanize .PublishedAt}}_)
+{{- end}}
+
+***
+
+Part of [Charm](https://charm.sh).
+
+<a href="https://charm.sh/"><img alt="The Charm logo" src="https://stuff.charm.sh/charm-badge.jpg" width="400"></a>


### PR DESCRIPTION
Add the team information to map blog post authors to team member's githubs